### PR TITLE
Removed obsolete `slugify` function from `seed.ts` script

### DIFF
--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -31,13 +31,6 @@ function daysAgo(n: number): string {
   return d.toISOString();
 }
 
-function slugify(title: string): string {
-  return title
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/(^-|-$)/g, "");
-}
-
 // ─── Seed Data ───
 
 async function seed() {


### PR DESCRIPTION
I followed the setup instructions at https://www.aihero.dev/workshops/before-we-start-fuywo/repo-setup~0977a and peeked at the seed script, then saw that the VS Code lint said `slugify` is never read:

<img width="617" height="272" alt="image" src="https://github.com/user-attachments/assets/df180ac7-dcd9-4d07-bf35-45912124fa94" />

The seed command `pnpm db:seed` runs successfully without it and it's also not `export`-ed, so I think it's safe to remove.