### PR TITLE
Upgrade better-sqlite3 to 12 to support Node 24

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@react-router/node": "7.12.0",
     "@react-router/serve": "7.12.0",
     "@tailwindcss/typography": "^0.5.19",
-    "better-sqlite3": "^11.9.1",
+    "better-sqlite3": "^12.8.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "drizzle-orm": "^0.44.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^0.5.19
         version: 0.5.19(tailwindcss@4.1.18)
       better-sqlite3:
-        specifier: ^11.9.1
-        version: 11.10.0
+        specifier: ^12.8.0
+        version: 12.8.0
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -34,7 +34,7 @@ importers:
         version: 2.1.1
       drizzle-orm:
         specifier: ^0.44.2
-        version: 0.44.7(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)
+        version: 0.44.7(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)
       isbot:
         specifier: ^5.1.31
         version: 5.1.34
@@ -2030,8 +2030,9 @@ packages:
     resolution: {integrity: sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==}
     engines: {node: '>= 0.8'}
 
-  better-sqlite3@11.10.0:
-    resolution: {integrity: sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==}
+  better-sqlite3@12.8.0:
+    resolution: {integrity: sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
 
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
@@ -3317,6 +3318,7 @@ packages:
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
   prettier@3.8.1:
@@ -5842,7 +5844,7 @@ snapshots:
     dependencies:
       safe-buffer: 5.1.2
 
-  better-sqlite3@11.10.0:
+  better-sqlite3@12.8.0:
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.3
@@ -6113,10 +6115,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.44.7(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0):
+  drizzle-orm@0.44.7(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0):
     optionalDependencies:
       '@types/better-sqlite3': 7.6.13
-      better-sqlite3: 11.10.0
+      better-sqlite3: 12.8.0
 
   dunder-proto@1.0.1:
     dependencies:


### PR DESCRIPTION
When running `pnpm db:migrate` with Node.js 24, we get the error below. This is because better-sqlite3 v11 does not support Node.js 24. Upgrading to 12 fix the issue.

Looking at the [breaking changes of v12](https://github.com/WiseLibs/better-sqlite3/releases/tag/v12.0.0), it no longer support Node 18 which should be fine.

Looking forward to this course, it looks well though out and awesome 😀

```bash
Error: Could not locate the bindings file. Tried:
 → /Users/benoitt/cohort-003-project/node_modules/.pnpm/better-sqlite3@11.10.0/node_modules/better-sqlite3/build/better_sqlite3.node
 → /Users/benoitt/cohort-003-project/node_modules/.pnpm/better-sqlite3@11.10.0/node_modules/better-sqlite3/build/Debug/better_sqlite3.node
 → /Users/benoitt/cohort-003-project/node_modules/.pnpm/better-sqlite3@11.10.0/node_modules/better-sqlite3/build/Release/better_sqlite3.node
 → /Users/benoitt/cohort-003-project/node_modules/.pnpm/better-sqlite3@11.10.0/node_modules/better-sqlite3/out/Debug/better_sqlite3.node
 → /Users/benoitt/cohort-003-project/node_modules/.pnpm/better-sqlite3@11.10.0/node_modules/better-sqlite3/Debug/better_sqlite3.node
 → /Users/benoitt/cohort-003-project/node_modules/.pnpm/better-sqlite3@11.10.0/node_modules/better-sqlite3/out/Release/better_sqlite3.node
 → /Users/benoitt/cohort-003-project/node_modules/.pnpm/better-sqlite3@11.10.0/node_modules/better-sqlite3/Release/better_sqlite3.node
 → /Users/benoitt/cohort-003-project/node_modules/.pnpm/better-sqlite3@11.10.0/node_modules/better-sqlite3/build/default/better_sqlite3.node
 → /Users/benoitt/cohort-003-project/node_modules/.pnpm/better-sqlite3@11.10.0/node_modules/better-sqlite3/compiled/24.14.0/darwin/arm64/better_sqlite3.node
 → /Users/benoitt/cohort-003-project/node_modules/.pnpm/better-sqlite3@11.10.0/node_modules/better-sqlite3/addon-build/release/install-root/better_sqlite3.node
 → /Users/benoitt/cohort-003-project/node_modules/.pnpm/better-sqlite3@11.10.0/node_modules/better-sqlite3/addon-build/debug/install-root/better_sqlite3.node
 → /Users/benoitt/cohort-003-project/node_modules/.pnpm/better-sqlite3@11.10.0/node_modules/better-sqlite3/addon-build/default/install-root/better_sqlite3.node
 → /Users/benoitt/cohort-003-project/node_modules/.pnpm/better-sqlite3@11.10.0/node_modules/better-sqlite3/lib/binding/node-v137-darwin-arm64/better_sqlite3.node
    at bindings (/Users/benoitt/cohort-003-project/node_modules/.pnpm/bindings@1.5.0/node_modules/bindings/bindings.js:126:9)
    at new Database (/Users/benoitt/cohort-003-project/node_modules/.pnpm/better-sqlite3@11.10.0/node_modules/better-sqlite3/lib/database.js:48:64)
    at connectToSQLite (/Users/benoitt/cohort-003-project/node_modules/.pnpm/drizzle-kit@0.31.8/node_modules/drizzle-kit/bin.cjs:81302:24)
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
    at async Object.handler (/Users/benoitt/cohort-003-project/node_modules/.pnpm/drizzle-kit@0.31.8/node_modules/drizzle-kit/bin.cjs:93722:39)
    at async run (/Users/benoitt/cohort-003-project/node_modules/.pnpm/drizzle-kit@0.31.8/node_modules/drizzle-kit/bin.cjs:93117:7)
```