### PR TITLE
gitignore the jetbrains project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 .pnpm-store
 *.db-shm
 .claude/settings.local.json
+
+# jetbrains project files
+.idea/


### PR DESCRIPTION
Simple change to ignore jetbrains project files (webstorm, etc).  all files under ./.idea/ can be ignored.  

FYI This is not good project form (some of these files should be committed for a real project) but very appropriate for a class without a specified IDE.