### PR TITLE
Add /hello route via Ralph AFK experiment

### DIFF
--- a/app/routes.ts
+++ b/app/routes.ts
@@ -50,4 +50,5 @@ export default [
   route("api/logout", "routes/api.logout.ts"),
   route("api/video-tracking", "routes/api.video-tracking.ts"),
   route("api/set-dev-country", "routes/api.set-dev-country.ts"),
+  route("hello", "routes/hello.tsx"),
 ] satisfies RouteConfig;

--- a/app/routes/hello.tsx
+++ b/app/routes/hello.tsx
@@ -1,0 +1,3 @@
+export default function Hello() {
+  return <h1>Hello from Ralph!</h1>;
+}

--- a/ralph/test-prd.md
+++ b/ralph/test-prd.md
@@ -1,0 +1,19 @@
+# PRD: Add a hello route
+
+## Context
+Testing the Ralph AFK loop on a minimal task.
+
+## Task
+Add a new file `app/routes/hello.tsx` that renders a React component saying "Hello from Ralph!".
+
+Wire it into `app/routes.ts` (React Router v7 file-based routing) so that visiting `/hello` renders the component.
+
+## Success criteria
+- [ ] `app/routes/hello.tsx` exists and exports a default React component
+- [ ] Route is registered in `app/routes.ts`
+- [ ] `pnpm typecheck` passes
+- [ ] `pnpm test` passes (or no test is required if none exist for this route)
+
+## Out of scope
+- Styling beyond a simple `<h1>` tag
+- Tests for the new route (keep it minimal)


### PR DESCRIPTION
First Ralph run on PRD ralph/test-prd.md.
- app/routes/hello.tsx: new React component
- app/routes.ts: registered /hello
- pnpm typecheck passes

Ralph stopped at git commit step due to acceptEdits permission mode; committed manually.