### PR TITLE
chore: migrate validation layer from Zod to Valibot

### DIFF
--- a/app/lib/validation.ts
+++ b/app/lib/validation.ts
@@ -1,5 +1,5 @@
 import { data } from "react-router";
-import type { z } from "zod";
+import * as v from "valibot";
 
 type ParseSuccess<T> = { success: true; data: T };
 type ParseFailure = {
@@ -9,25 +9,27 @@ type ParseFailure = {
 type ParseResult<T> = ParseSuccess<T> | ParseFailure;
 
 /**
- * Converts FormData to a plain object, validates with a Zod schema,
+ * Converts FormData to a plain object, validates with a Valibot schema,
  * and returns either the parsed data or a field-error map (first error per field).
  */
-export function parseFormData<T extends z.ZodType>(
+export function parseFormData<T extends v.GenericSchema>(
   formData: FormData,
   schema: T
-): ParseResult<z.infer<T>> {
+): ParseResult<v.InferOutput<T>> {
   const raw = Object.fromEntries(formData);
-  const result = schema.safeParse(raw);
+  const result = v.safeParse(schema, raw);
 
   if (result.success) {
-    return { success: true, data: result.data };
+    return { success: true, data: result.output };
   }
 
-  const fieldErrors = result.error.flatten().fieldErrors;
+  const fieldErrors = v.flatten(result.issues).nested;
   const errors: Record<string, string> = {};
-  for (const [key, messages] of Object.entries(fieldErrors)) {
-    if (messages && messages.length > 0) {
-      errors[key] = messages[0];
+  if (fieldErrors) {
+    for (const [key, messages] of Object.entries(fieldErrors)) {
+      if (messages && messages.length > 0) {
+        errors[key] = messages[0];
+      }
     }
   }
 
@@ -35,42 +37,44 @@ export function parseFormData<T extends z.ZodType>(
 }
 
 /**
- * Validates route params with a Zod schema.
+ * Validates route params with a Valibot schema.
  * Throws a 400 response on failure (params are never user-correctable form errors).
  */
-export function parseParams<T extends z.ZodType>(
+export function parseParams<T extends v.GenericSchema>(
   params: Record<string, string | undefined>,
   schema: T
-): z.infer<T> {
-  const result = schema.safeParse(params);
+): v.InferOutput<T> {
+  const result = v.safeParse(schema, params);
 
   if (result.success) {
-    return result.data;
+    return result.output;
   }
 
   throw data("Invalid parameters", { status: 400 });
 }
 
 /**
- * Parses a JSON request body with a Zod schema.
+ * Parses a JSON request body with a Valibot schema.
  * Returns either the parsed data or a field-error map (first error per field).
  */
-export async function parseJsonBody<T extends z.ZodType>(
+export async function parseJsonBody<T extends v.GenericSchema>(
   request: Request,
   schema: T
-): Promise<ParseResult<z.infer<T>>> {
+): Promise<ParseResult<v.InferOutput<T>>> {
   const raw = await request.json();
-  const result = schema.safeParse(raw);
+  const result = v.safeParse(schema, raw);
 
   if (result.success) {
-    return { success: true, data: result.data };
+    return { success: true, data: result.output };
   }
 
-  const fieldErrors = result.error.flatten().fieldErrors;
+  const fieldErrors = v.flatten(result.issues).nested;
   const errors: Record<string, string> = {};
-  for (const [key, messages] of Object.entries(fieldErrors)) {
-    if (messages && messages.length > 0) {
-      errors[key] = messages[0];
+  if (fieldErrors) {
+    for (const [key, messages] of Object.entries(fieldErrors)) {
+      if (messages && messages.length > 0) {
+        errors[key] = messages[0];
+      }
     }
   }
 

--- a/app/routes/admin.categories.tsx
+++ b/app/routes/admin.categories.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect } from "react";
 import { useFetcher } from "react-router";
 import { toast } from "sonner";
-import { z } from "zod";
+import * as v from "valibot";
 import type { Route } from "./+types/admin.categories";
 import {
   getAllCategoriesWithCourseCounts,
@@ -20,19 +20,37 @@ import { Skeleton } from "~/components/ui/skeleton";
 import { AlertTriangle, BookOpen, Pencil, Plus, Tag, Trash2 } from "lucide-react";
 import { data, isRouteErrorResponse, Link } from "react-router";
 
-const adminCategoryActionSchema = z.discriminatedUnion("intent", [
-  z.object({
-    intent: z.literal("create"),
-    name: z.string().trim().min(1, "Category name cannot be empty."),
+const adminCategoryActionSchema = v.variant("intent", [
+  v.object({
+    intent: v.literal("create"),
+    name: v.pipe(
+      v.string(),
+      v.trim(),
+      v.nonEmpty("Category name cannot be empty.")
+    ),
   }),
-  z.object({
-    intent: z.literal("update"),
-    categoryId: z.coerce.number().int(),
-    name: z.string().trim().min(1, "Category name cannot be empty."),
+  v.object({
+    intent: v.literal("update"),
+    categoryId: v.pipe(
+      v.unknown(),
+      v.transform(Number),
+      v.number(),
+      v.integer()
+    ),
+    name: v.pipe(
+      v.string(),
+      v.trim(),
+      v.nonEmpty("Category name cannot be empty.")
+    ),
   }),
-  z.object({
-    intent: z.literal("delete"),
-    categoryId: z.coerce.number().int(),
+  v.object({
+    intent: v.literal("delete"),
+    categoryId: v.pipe(
+      v.unknown(),
+      v.transform(Number),
+      v.number(),
+      v.integer()
+    ),
   }),
 ]);
 

--- a/app/routes/admin.courses.tsx
+++ b/app/routes/admin.courses.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { useFetcher } from "react-router";
 import { toast } from "sonner";
-import { z } from "zod";
+import * as v from "valibot";
 import type { Route } from "./+types/admin.courses";
 import {
   getAllCourses,
@@ -26,11 +26,16 @@ import {
 import { AlertTriangle, BookOpen, Users } from "lucide-react";
 import { data, isRouteErrorResponse, Link } from "react-router";
 
-const adminCourseActionSchema = z.discriminatedUnion("intent", [
-  z.object({
-    intent: z.literal("update-status"),
-    courseId: z.coerce.number().int(),
-    status: z.nativeEnum(CourseStatus),
+const adminCourseActionSchema = v.variant("intent", [
+  v.object({
+    intent: v.literal("update-status"),
+    courseId: v.pipe(
+      v.unknown(),
+      v.transform(Number),
+      v.number(),
+      v.integer()
+    ),
+    status: v.enum(CourseStatus),
   }),
 ]);
 

--- a/app/routes/admin.users.tsx
+++ b/app/routes/admin.users.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect } from "react";
 import { useFetcher } from "react-router";
 import { toast } from "sonner";
-import { z } from "zod";
+import * as v from "valibot";
 import type { Route } from "./+types/admin.users";
 import { getAllUsers, updateUser, updateUserRole } from "~/services/userService";
 import { getCurrentUserId } from "~/lib/session";
@@ -21,17 +21,27 @@ import {
 import { AlertTriangle, Pencil, Shield, Users } from "lucide-react";
 import { data, isRouteErrorResponse, Link } from "react-router";
 
-const adminUserActionSchema = z.discriminatedUnion("intent", [
-  z.object({
-    intent: z.literal("update-user"),
-    userId: z.coerce.number().int(),
-    name: z.string().trim().min(1, "Name cannot be empty."),
-    email: z.string().trim().min(1, "Email cannot be empty."),
+const adminUserActionSchema = v.variant("intent", [
+  v.object({
+    intent: v.literal("update-user"),
+    userId: v.pipe(
+      v.unknown(),
+      v.transform(Number),
+      v.number(),
+      v.integer()
+    ),
+    name: v.pipe(v.string(), v.trim(), v.nonEmpty("Name cannot be empty.")),
+    email: v.pipe(v.string(), v.trim(), v.nonEmpty("Email cannot be empty.")),
   }),
-  z.object({
-    intent: z.literal("update-role"),
-    userId: z.coerce.number().int(),
-    role: z.nativeEnum(UserRole),
+  v.object({
+    intent: v.literal("update-role"),
+    userId: v.pipe(
+      v.unknown(),
+      v.transform(Number),
+      v.number(),
+      v.integer()
+    ),
+    role: v.enum(UserRole),
   }),
 ]);
 

--- a/app/routes/api.set-dev-country.ts
+++ b/app/routes/api.set-dev-country.ts
@@ -1,11 +1,14 @@
 import { redirect } from "react-router";
-import { z } from "zod";
+import * as v from "valibot";
 import type { Route } from "./+types/api.set-dev-country";
 import { setDevCountry } from "~/lib/session";
 import { parseFormData } from "~/lib/validation";
 
-const setDevCountrySchema = z.object({
-  country: z.string().length(2).or(z.literal("")).transform((v) => v || null),
+const setDevCountrySchema = v.object({
+  country: v.pipe(
+    v.union([v.pipe(v.string(), v.length(2)), v.literal("")]),
+    v.transform((value) => value || null)
+  ),
 });
 
 export async function action({ request }: Route.ActionArgs) {

--- a/app/routes/api.switch-user.ts
+++ b/app/routes/api.switch-user.ts
@@ -1,11 +1,17 @@
 import { redirect } from "react-router";
-import { z } from "zod";
+import * as v from "valibot";
 import type { Route } from "./+types/api.switch-user";
 import { setCurrentUserId } from "~/lib/session";
 import { parseFormData } from "~/lib/validation";
 
-const switchUserSchema = z.object({
-  userId: z.coerce.number().int().positive("Invalid user ID"),
+const switchUserSchema = v.object({
+  userId: v.pipe(
+    v.unknown(),
+    v.transform(Number),
+    v.number(),
+    v.integer(),
+    v.gtValue(0, "Invalid user ID")
+  ),
 });
 
 export async function action({ request }: Route.ActionArgs) {

--- a/app/routes/api.video-tracking.ts
+++ b/app/routes/api.video-tracking.ts
@@ -1,14 +1,14 @@
 import { data } from "react-router";
-import { z } from "zod";
+import * as v from "valibot";
 import type { Route } from "./+types/api.video-tracking";
 import { getCurrentUserId } from "~/lib/session";
 import { logWatchEvent } from "~/services/videoTrackingService";
 import { parseJsonBody } from "~/lib/validation";
 
-const videoTrackingSchema = z.object({
-  lessonId: z.number(),
-  eventType: z.string(),
-  positionSeconds: z.number(),
+const videoTrackingSchema = v.object({
+  lessonId: v.number(),
+  eventType: v.string(),
+  positionSeconds: v.number(),
 });
 
 export async function action({ request }: Route.ActionArgs) {

--- a/app/routes/courses.$slug.$moduleId.tsx
+++ b/app/routes/courses.$slug.$moduleId.tsx
@@ -25,11 +25,11 @@ import {
 } from "lucide-react";
 import { data, isRouteErrorResponse } from "react-router";
 import { formatDuration } from "~/lib/utils";
-import { z } from "zod";
+import * as v from "valibot";
 
-const paramsSchema = z.object({
-  slug: z.string().min(1),
-  moduleId: z.coerce.number().int(),
+const paramsSchema = v.object({
+  slug: v.pipe(v.string(), v.nonEmpty()),
+  moduleId: v.pipe(v.unknown(), v.transform(Number), v.number(), v.integer()),
 });
 
 export function meta({ data: loaderData }: Route.MetaArgs) {
@@ -39,12 +39,12 @@ export function meta({ data: loaderData }: Route.MetaArgs) {
 }
 
 export async function loader({ params, request }: Route.LoaderArgs) {
-  const parsed = paramsSchema.safeParse(params);
+  const parsed = v.safeParse(paramsSchema, params);
   if (!parsed.success) {
     throw data("Invalid parameters", { status: 400 });
   }
 
-  const { slug, moduleId } = parsed.data;
+  const { slug, moduleId } = parsed.output;
 
   const course = getCourseBySlug(slug);
   if (!course) {

--- a/app/routes/courses.$slug.lessons.$lessonId.tsx
+++ b/app/routes/courses.$slug.lessons.$lessonId.tsx
@@ -50,19 +50,19 @@ import { cn, formatDuration } from "~/lib/utils";
 import { renderMarkdown } from "~/lib/markdown.server";
 import { YouTubePlayer } from "~/components/youtube-player";
 import { data, isRouteErrorResponse } from "react-router";
-import { z } from "zod";
+import * as v from "valibot";
 import { resolveCountry } from "~/lib/country.server";
 import { checkPppAccess, COUNTRIES } from "~/lib/ppp";
 import { findPurchase } from "~/services/purchaseService";
 import { parseFormData, parseParams } from "~/lib/validation";
 
-const lessonParamsSchema = z.object({
-  slug: z.string().min(1),
-  lessonId: z.coerce.number().int(),
+const lessonParamsSchema = v.object({
+  slug: v.pipe(v.string(), v.nonEmpty()),
+  lessonId: v.pipe(v.unknown(), v.transform(Number), v.number(), v.integer()),
 });
 
-const markCompleteSchema = z.object({
-  intent: z.literal("mark-complete"),
+const markCompleteSchema = v.object({
+  intent: v.literal("mark-complete"),
 });
 
 export function meta({ data: loaderData }: Route.MetaArgs) {

--- a/app/routes/courses.$slug.purchase.tsx
+++ b/app/routes/courses.$slug.purchase.tsx
@@ -1,7 +1,7 @@
 import { Link, useFetcher, redirect, useSearchParams } from "react-router";
 import { useState, useEffect } from "react";
 import { toast } from "sonner";
-import { z } from "zod";
+import * as v from "valibot";
 import type { Route } from "./+types/courses.$slug.purchase";
 import {
   getCourseBySlug,
@@ -34,15 +34,21 @@ import { calculatePppPrice, getCountryTierInfo, COUNTRIES } from "~/lib/ppp";
 import { createPurchase, createTeamPurchase } from "~/services/purchaseService";
 import { parseFormData, parseParams } from "~/lib/validation";
 
-const purchaseParamsSchema = z.object({
-  slug: z.string().min(1),
+const purchaseParamsSchema = v.object({
+  slug: v.pipe(v.string(), v.nonEmpty()),
 });
 
-const purchaseActionSchema = z.discriminatedUnion("intent", [
-  z.object({ intent: z.literal("confirm-purchase") }),
-  z.object({
-    intent: z.literal("confirm-team-purchase"),
-    quantity: z.coerce.number().int().min(1),
+const purchaseActionSchema = v.variant("intent", [
+  v.object({ intent: v.literal("confirm-purchase") }),
+  v.object({
+    intent: v.literal("confirm-team-purchase"),
+    quantity: v.pipe(
+      v.unknown(),
+      v.transform(Number),
+      v.number(),
+      v.integer(),
+      v.minValue(1)
+    ),
   }),
 ]);
 

--- a/app/routes/instructor.$courseId.lessons.$lessonId.quiz.tsx
+++ b/app/routes/instructor.$courseId.lessons.$lessonId.quiz.tsx
@@ -49,42 +49,43 @@ import {
   type DropResult,
 } from "@hello-pangea/dnd";
 import { data, isRouteErrorResponse } from "react-router";
-import { z } from "zod";
+import * as v from "valibot";
 import { parseFormData, parseParams } from "~/lib/validation";
 
-const quizParamsSchema = z.object({
-  courseId: z.coerce.number().int(),
-  lessonId: z.coerce.number().int(),
+const quizParamsSchema = v.object({
+  courseId: v.pipe(v.unknown(), v.transform(Number), v.number(), v.integer()),
+  lessonId: v.pipe(v.unknown(), v.transform(Number), v.number(), v.integer()),
 });
 
-const wizardDataSchema = z.object({
-  title: z.string().trim().min(1, "Quiz title is required."),
-  passingScore: z.number(),
-  questions: z
-    .array(
-      z.object({
-        id: z.string(),
-        text: z.string(),
-        type: z.nativeEnum(QuestionType),
-        options: z.array(
-          z.object({
-            id: z.string(),
-            text: z.string(),
-            isCorrect: z.boolean(),
+const wizardDataSchema = v.object({
+  title: v.pipe(v.string(), v.trim(), v.nonEmpty("Quiz title is required.")),
+  passingScore: v.number(),
+  questions: v.pipe(
+    v.array(
+      v.object({
+        id: v.string(),
+        text: v.string(),
+        type: v.enum(QuestionType),
+        options: v.array(
+          v.object({
+            id: v.string(),
+            text: v.string(),
+            isCorrect: v.boolean(),
           })
         ),
       })
-    )
-    .min(1, "At least one question is required."),
+    ),
+    v.minLength(1, "At least one question is required.")
+  ),
 });
 
-const quizActionSchema = z.discriminatedUnion("intent", [
-  z.object({
-    intent: z.literal("save-quiz"),
-    wizardData: z.string(),
+const quizActionSchema = v.variant("intent", [
+  v.object({
+    intent: v.literal("save-quiz"),
+    wizardData: v.string(),
   }),
-  z.object({
-    intent: z.literal("delete-quiz"),
+  v.object({
+    intent: v.literal("delete-quiz"),
   }),
 ]);
 
@@ -218,14 +219,14 @@ export async function action({ params, request }: Route.ActionArgs) {
   const { intent } = parsed.data;
 
   if (intent === "save-quiz") {
-    let wizardData: z.infer<typeof wizardDataSchema>;
+    let wizardData: v.InferOutput<typeof wizardDataSchema>;
     try {
       const raw = JSON.parse(parsed.data.wizardData);
-      const wizardResult = wizardDataSchema.safeParse(raw);
+      const wizardResult = v.safeParse(wizardDataSchema, raw);
       if (!wizardResult.success) {
         return data({ error: "Invalid quiz data." }, { status: 400 });
       }
-      wizardData = wizardResult.data;
+      wizardData = wizardResult.output;
     } catch {
       return data({ error: "Invalid quiz data." }, { status: 400 });
     }

--- a/app/routes/instructor.$courseId.lessons.$lessonId.tsx
+++ b/app/routes/instructor.$courseId.lessons.$lessonId.tsx
@@ -16,20 +16,20 @@ import { Label } from "~/components/ui/label";
 import { MonacoMarkdownEditor } from "~/components/monaco-markdown-editor";
 import { AlertTriangle, ArrowLeft, ClipboardList, ExternalLink, Github, Save } from "lucide-react";
 import { data, isRouteErrorResponse } from "react-router";
-import { z } from "zod";
+import * as v from "valibot";
 import { parseFormData, parseParams } from "~/lib/validation";
 
-const instructorLessonParamsSchema = z.object({
-  courseId: z.coerce.number().int(),
-  lessonId: z.coerce.number().int(),
+const instructorLessonParamsSchema = v.object({
+  courseId: v.pipe(v.unknown(), v.transform(Number), v.number(), v.integer()),
+  lessonId: v.pipe(v.unknown(), v.transform(Number), v.number(), v.integer()),
 });
 
-const updateLessonSchema = z.object({
-  intent: z.literal("update-lesson"),
-  content: z.string().optional(),
-  videoUrl: z.string().trim().optional(),
-  durationMinutes: z.string().optional(),
-  githubRepoUrl: z.string().trim().optional(),
+const updateLessonSchema = v.object({
+  intent: v.literal("update-lesson"),
+  content: v.optional(v.string()),
+  videoUrl: v.optional(v.pipe(v.string(), v.trim())),
+  durationMinutes: v.optional(v.string()),
+  githubRepoUrl: v.optional(v.pipe(v.string(), v.trim())),
 });
 
 export function meta({ data: loaderData }: Route.MetaArgs) {

--- a/app/routes/instructor.$courseId.modules.$moduleId.tsx
+++ b/app/routes/instructor.$courseId.modules.$moduleId.tsx
@@ -21,11 +21,11 @@ import {
 } from "lucide-react";
 import { data, isRouteErrorResponse } from "react-router";
 import { formatDuration } from "~/lib/utils";
-import { z } from "zod";
+import * as v from "valibot";
 
-const paramsSchema = z.object({
-  courseId: z.coerce.number().int(),
-  moduleId: z.coerce.number().int(),
+const paramsSchema = v.object({
+  courseId: v.pipe(v.unknown(), v.transform(Number), v.number(), v.integer()),
+  moduleId: v.pipe(v.unknown(), v.transform(Number), v.number(), v.integer()),
 });
 
 export function meta({ data: loaderData }: Route.MetaArgs) {
@@ -54,12 +54,12 @@ export async function loader({ params, request }: Route.LoaderArgs) {
     });
   }
 
-  const parsed = paramsSchema.safeParse(params);
+  const parsed = v.safeParse(paramsSchema, params);
   if (!parsed.success) {
     throw data("Invalid parameters", { status: 400 });
   }
 
-  const { courseId, moduleId } = parsed.data;
+  const { courseId, moduleId } = parsed.output;
 
   const course = getCourseById(courseId);
   if (!course) {

--- a/app/routes/instructor.$courseId.tsx
+++ b/app/routes/instructor.$courseId.tsx
@@ -71,29 +71,104 @@ import {
   FileText,
 } from "lucide-react";
 import { data, isRouteErrorResponse } from "react-router";
-import { z } from "zod";
+import * as v from "valibot";
 import { parseFormData, parseParams } from "~/lib/validation";
 
-const courseEditorParamsSchema = z.object({
-  courseId: z.coerce.number().int(),
+const courseEditorParamsSchema = v.object({
+  courseId: v.pipe(v.unknown(), v.transform(Number), v.number(), v.integer()),
 });
 
-const courseEditorActionSchema = z.discriminatedUnion("intent", [
-  z.object({ intent: z.literal("update-title"), title: z.string().trim().min(1, "Title cannot be empty.") }),
-  z.object({ intent: z.literal("update-description"), description: z.string().trim().min(1, "Description cannot be empty.") }),
-  z.object({ intent: z.literal("update-status"), status: z.nativeEnum(CourseStatus) }),
-  z.object({ intent: z.literal("update-price"), price: z.string() }),
-  z.object({ intent: z.literal("update-ppp-enabled"), pppEnabled: z.string() }),
-  z.object({ intent: z.literal("add-module"), title: z.string().trim().min(1, "Module title cannot be empty.") }),
-  z.object({ intent: z.literal("rename-module"), moduleId: z.coerce.number().int(), title: z.string().trim().min(1, "Module title cannot be empty.") }),
-  z.object({ intent: z.literal("delete-module"), moduleId: z.coerce.number().int() }),
-  z.object({ intent: z.literal("add-lesson"), moduleId: z.coerce.number().int(), title: z.string().trim().min(1, "Lesson title cannot be empty.") }),
-  z.object({ intent: z.literal("rename-lesson"), lessonId: z.coerce.number().int(), title: z.string().trim().min(1, "Lesson title cannot be empty.") }),
-  z.object({ intent: z.literal("reorder-modules"), moduleIds: z.string().min(1, "Missing module IDs.") }),
-  z.object({ intent: z.literal("reorder-lessons"), moduleId: z.coerce.number().int(), lessonIds: z.string().min(1, "Missing lesson IDs.") }),
-  z.object({ intent: z.literal("move-lesson"), lessonId: z.coerce.number().int(), targetModuleId: z.coerce.number().int(), targetPosition: z.coerce.number().int() }),
-  z.object({ intent: z.literal("delete-lesson"), lessonId: z.coerce.number().int() }),
-  z.object({ intent: z.literal("update-sales-copy"), salesCopy: z.string().optional() }),
+const coerceInt = v.pipe(
+  v.unknown(),
+  v.transform(Number),
+  v.number(),
+  v.integer()
+);
+
+const courseEditorActionSchema = v.variant("intent", [
+  v.object({
+    intent: v.literal("update-title"),
+    title: v.pipe(v.string(), v.trim(), v.nonEmpty("Title cannot be empty.")),
+  }),
+  v.object({
+    intent: v.literal("update-description"),
+    description: v.pipe(
+      v.string(),
+      v.trim(),
+      v.nonEmpty("Description cannot be empty.")
+    ),
+  }),
+  v.object({
+    intent: v.literal("update-status"),
+    status: v.enum(CourseStatus),
+  }),
+  v.object({ intent: v.literal("update-price"), price: v.string() }),
+  v.object({
+    intent: v.literal("update-ppp-enabled"),
+    pppEnabled: v.string(),
+  }),
+  v.object({
+    intent: v.literal("add-module"),
+    title: v.pipe(
+      v.string(),
+      v.trim(),
+      v.nonEmpty("Module title cannot be empty.")
+    ),
+  }),
+  v.object({
+    intent: v.literal("rename-module"),
+    moduleId: coerceInt,
+    title: v.pipe(
+      v.string(),
+      v.trim(),
+      v.nonEmpty("Module title cannot be empty.")
+    ),
+  }),
+  v.object({
+    intent: v.literal("delete-module"),
+    moduleId: coerceInt,
+  }),
+  v.object({
+    intent: v.literal("add-lesson"),
+    moduleId: coerceInt,
+    title: v.pipe(
+      v.string(),
+      v.trim(),
+      v.nonEmpty("Lesson title cannot be empty.")
+    ),
+  }),
+  v.object({
+    intent: v.literal("rename-lesson"),
+    lessonId: coerceInt,
+    title: v.pipe(
+      v.string(),
+      v.trim(),
+      v.nonEmpty("Lesson title cannot be empty.")
+    ),
+  }),
+  v.object({
+    intent: v.literal("reorder-modules"),
+    moduleIds: v.pipe(v.string(), v.nonEmpty("Missing module IDs.")),
+  }),
+  v.object({
+    intent: v.literal("reorder-lessons"),
+    moduleId: coerceInt,
+    lessonIds: v.pipe(v.string(), v.nonEmpty("Missing lesson IDs.")),
+  }),
+  v.object({
+    intent: v.literal("move-lesson"),
+    lessonId: coerceInt,
+    targetModuleId: coerceInt,
+    targetPosition: coerceInt,
+  }),
+  v.object({
+    intent: v.literal("delete-lesson"),
+    lessonId: coerceInt,
+  }),
+  v.object({
+    intent: v.literal("update-sales-copy"),
+    salesCopy: v.optional(v.string()),
+  }),
 ]);
 
 export function meta({ data: loaderData }: Route.MetaArgs) {

--- a/app/routes/instructor.new.tsx
+++ b/app/routes/instructor.new.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { Link, redirect, useFetcher } from "react-router";
 import { toast } from "sonner";
-import { z } from "zod";
+import * as v from "valibot";
 import type { Route } from "./+types/instructor.new";
 import { createCourse, getCourseBySlug } from "~/services/courseService";
 import { getAllCategories, slugify as generateSlug } from "~/services/categoryService";
@@ -24,11 +24,15 @@ import {
 import { AlertTriangle, ArrowLeft } from "lucide-react";
 import { data, isRouteErrorResponse } from "react-router";
 
-const newCourseSchema = z.object({
-  title: z.string().trim().min(1, "Title is required."),
-  description: z.string().trim().min(1, "Description is required."),
-  categoryId: z.string().min(1, "Category is required."),
-  coverImageUrl: z.string().trim().optional(),
+const newCourseSchema = v.object({
+  title: v.pipe(v.string(), v.trim(), v.nonEmpty("Title is required.")),
+  description: v.pipe(
+    v.string(),
+    v.trim(),
+    v.nonEmpty("Description is required.")
+  ),
+  categoryId: v.pipe(v.string(), v.nonEmpty("Category is required.")),
+  coverImageUrl: v.optional(v.pipe(v.string(), v.trim())),
 });
 
 export function meta() {

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -1,6 +1,6 @@
 import { Form, Link, useActionData, useNavigation, useSearchParams } from "react-router";
 import { redirect, data } from "react-router";
-import { z } from "zod";
+import * as v from "valibot";
 import type { Route } from "./+types/login";
 import { getUserByEmail } from "~/services/userService";
 import { setCurrentUserId, getCurrentUserId } from "~/lib/session";
@@ -9,13 +9,14 @@ import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
 import { Card, CardContent } from "~/components/ui/card";
 
-const loginSchema = z.object({
-  email: z
-    .string()
-    .trim()
-    .toLowerCase()
-    .min(1, "Email is required.")
-    .email("Please enter a valid email address."),
+const loginSchema = v.object({
+  email: v.pipe(
+    v.string(),
+    v.trim(),
+    v.toLowerCase(),
+    v.nonEmpty("Email is required."),
+    v.email("Please enter a valid email address.")
+  ),
 });
 
 export function meta() {

--- a/app/routes/redeem.$code.tsx
+++ b/app/routes/redeem.$code.tsx
@@ -1,7 +1,7 @@
 import { Link, useFetcher, redirect } from "react-router";
 import { useEffect } from "react";
 import { toast } from "sonner";
-import { z } from "zod";
+import * as v from "valibot";
 import type { Route } from "./+types/redeem.$code";
 import { getCourseById } from "~/services/courseService";
 import { getCouponByCode, redeemCoupon } from "~/services/couponService";
@@ -17,12 +17,12 @@ import { db } from "~/db";
 import { purchases } from "~/db/schema";
 import { eq } from "drizzle-orm";
 
-const redeemParamsSchema = z.object({
-  code: z.string().min(1),
+const redeemParamsSchema = v.object({
+  code: v.pipe(v.string(), v.nonEmpty()),
 });
 
-const redeemActionSchema = z.object({
-  intent: z.literal("confirm-redeem"),
+const redeemActionSchema = v.object({
+  intent: v.literal("confirm-redeem"),
 });
 
 export function meta({ data: loaderData }: Route.MetaArgs) {

--- a/app/routes/settings.tsx
+++ b/app/routes/settings.tsx
@@ -1,7 +1,7 @@
 import { useRef, useEffect } from "react";
 import { useFetcher } from "react-router";
 import { toast } from "sonner";
-import { z } from "zod";
+import * as v from "valibot";
 import type { Route } from "./+types/settings";
 import { getCurrentUserId } from "~/lib/session";
 import { getUserById, updateUser } from "~/services/userService";
@@ -15,9 +15,9 @@ import { UserRole } from "~/db/schema";
 import { AlertTriangle } from "lucide-react";
 import { data, isRouteErrorResponse, Link } from "react-router";
 
-const settingsSchema = z.object({
-  name: z.string().trim().min(1, "Name cannot be empty."),
-  bio: z.string().trim().optional(),
+const settingsSchema = v.object({
+  name: v.pipe(v.string(), v.trim(), v.nonEmpty("Name cannot be empty.")),
+  bio: v.optional(v.pipe(v.string(), v.trim())),
 });
 
 export function meta() {

--- a/app/routes/signup.tsx
+++ b/app/routes/signup.tsx
@@ -1,6 +1,6 @@
 import { Form, Link, useActionData, useNavigation, useSearchParams } from "react-router";
 import { redirect, data } from "react-router";
-import { z } from "zod";
+import * as v from "valibot";
 import type { Route } from "./+types/signup";
 import { getUserByEmail, createUser } from "~/services/userService";
 import { UserRole } from "~/db/schema";
@@ -10,14 +10,15 @@ import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
 import { Card, CardContent, CardHeader } from "~/components/ui/card";
 
-const signupSchema = z.object({
-  name: z.string().trim().min(1, "Name is required."),
-  email: z
-    .string()
-    .trim()
-    .toLowerCase()
-    .min(1, "Email is required.")
-    .email("Please enter a valid email address."),
+const signupSchema = v.object({
+  name: v.pipe(v.string(), v.trim(), v.nonEmpty("Name is required.")),
+  email: v.pipe(
+    v.string(),
+    v.trim(),
+    v.toLowerCase(),
+    v.nonEmpty("Email is required."),
+    v.email("Please enter a valid email address.")
+  ),
 });
 
 export function meta() {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "shiki": "^3.22.0",
     "sonner": "^2.0.3",
     "tailwind-merge": "^3.4.0",
-    "zod": "^3.25.36"
+    "valibot": "^1.4.1"
   },
   "devDependencies": {
     "@react-router/dev": "7.12.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,9 +68,9 @@ importers:
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0
-      zod:
-        specifier: ^3.25.36
-        version: 3.25.76
+      valibot:
+        specifier: ^1.4.1
+        version: 1.4.1(typescript@5.9.3)
     devDependencies:
       '@react-router/dev':
         specifier: 7.12.0
@@ -3887,8 +3887,8 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
-  valibot@1.2.0:
-    resolution: {integrity: sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==}
+  valibot@1.4.1:
+    resolution: {integrity: sha512-klCmFTz2jeDluy9RwX+F884TCiogtdBJ/YaxSx1EOBYXa3NXNWj8kR1jjN8rzluwojJVWWaHJ4r1U5LfICnM3g==}
     peerDependencies:
       typescript: '>=5'
     peerDependenciesMeta:
@@ -5445,7 +5445,7 @@ snapshots:
       react-router: 7.12.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       semver: 7.7.4
       tinyglobby: 0.2.15
-      valibot: 1.2.0(typescript@5.9.3)
+      valibot: 1.4.1(typescript@5.9.3)
       vite: 7.3.1(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
       vite-node: 3.2.4(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
     optionalDependencies:
@@ -7742,7 +7742,7 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
-  valibot@1.2.0(typescript@5.9.3):
+  valibot@1.4.1(typescript@5.9.3):
     optionalDependencies:
       typescript: 5.9.3
 


### PR DESCRIPTION
## Summary

Migrate the entire validation layer from **Zod** (`^3.25.36`) to **Valibot** (`^1.4.1`).

- 19 source files migrated + `package.json` + `pnpm-lock.yaml`
- 322 insertions, 188 deletions
- `app/lib/validation.ts` (the generic `parseFormData` / `parseParams` / `parseJsonBody` utilities) is the keystone — once it switched to Valibot's `v.GenericSchema` / `v.InferOutput` / `v.flatten(...).nested` shape, every route's schema fell into place

## Why Valibot

Valibot is the most modular and tree-shakable Zod alternative. Each schema function is imported independently, so bundlers can drop everything unused — a meaningful win for client-bundle size versus Zod's monolithic class chain. The API surface for the patterns this app uses (objects, discriminated unions, coerce, trim/lowercase, refines) is fully covered.

## Mapping highlights

| Zod | Valibot |
| --- | --- |
| `z.string().trim().min(1).email()` | `v.pipe(v.string(), v.trim(), v.nonEmpty(), v.email())` |
| `z.discriminatedUnion("intent", [...])` | `v.variant("intent", [...])` |
| `z.coerce.number().int().positive()` | `v.pipe(v.unknown(), v.transform(Number), v.number(), v.integer(), v.gtValue(0))` |
| `z.nativeEnum(MyEnum)` | `v.enum(MyEnum)` |
| `z.infer<typeof S>` | `v.InferOutput<typeof S>` |
| `z.ZodType` | `v.GenericSchema` |
| `schema.safeParse(data)` → `result.data` / `result.error` | `v.safeParse(schema, data)` → `result.output` / `result.issues` |
| `result.error.flatten().fieldErrors` | `v.flatten(result.issues).nested` |

A couple of non-obvious gotchas worth knowing for future review:
- `.min()` splits in Valibot — `v.minLength` on strings, `v.minValue` on numbers
- `.positive()` (strictly `> 0`) → `v.gtValue(0)`, not `v.minValue(0)`
- `v.optional(v.pipe(...))` wraps the pipe; it's **not** a pipe action

## Verification

- ✅ `pnpm typecheck` (`react-router typegen && tsc`)
- ✅ `pnpm test` — **11 test files, 278 tests passing**
- ✅ No remaining Zod references in app source (a transitive `zod@3.25.76` is still in `pnpm-lock.yaml` under `shadcn` → `@modelcontextprotocol/sdk`, which is a devDependency CLI tool not reachable from application code)

## Notes

This migration was produced by a `zod-to-valibot` skill that was authored and dry-run validated end-to-end against this repo before the PR — every translation in the mapping table above was exercised on real code in this codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
