### PR TITLE
Add star-only course ratings

### DIFF
--- a/app/components/star-rating.tsx
+++ b/app/components/star-rating.tsx
@@ -1,0 +1,133 @@
+import { useState } from "react";
+import { Form, useNavigation } from "react-router";
+import { Star } from "lucide-react";
+import { cn } from "~/lib/utils";
+import { MAX_RATING } from "~/db/schema";
+
+const STARS = Array.from({ length: MAX_RATING }, (_, i) => i + 1);
+
+/**
+ * Read-only average rating. Renders partial fills by overlaying a clipped row
+ * of solid stars on a row of outlines, so 4.3 reads as 4.3 rather than 4.
+ */
+export function StarRating({
+  average,
+  count,
+  size = "sm",
+  showCount = true,
+  className,
+}: {
+  average: number | null;
+  count: number;
+  size?: "sm" | "md";
+  showCount?: boolean;
+  className?: string;
+}) {
+  const starClass = size === "md" ? "size-5" : "size-3.5";
+  const textClass = size === "md" ? "text-sm" : "text-xs";
+
+  if (average === null || count === 0) {
+    return (
+      <span className={cn("text-muted-foreground", textClass, className)}>
+        No ratings yet
+      </span>
+    );
+  }
+
+  const fillPercent = (average / MAX_RATING) * 100;
+
+  return (
+    <span
+      className={cn("flex items-center gap-1.5", className)}
+      aria-label={`Rated ${average} out of ${MAX_RATING} from ${count} ${
+        count === 1 ? "rating" : "ratings"
+      }`}
+    >
+      <span className="relative inline-flex" aria-hidden="true">
+        <span className="flex">
+          {STARS.map((star) => (
+            <Star key={star} className={cn(starClass, "text-muted-foreground/40")} />
+          ))}
+        </span>
+        <span
+          className="absolute inset-0 flex overflow-hidden"
+          style={{ width: `${fillPercent}%` }}
+        >
+          {STARS.map((star) => (
+            <Star
+              key={star}
+              className={cn(starClass, "shrink-0 fill-amber-400 text-amber-400")}
+            />
+          ))}
+        </span>
+      </span>
+      <span className={cn("font-medium text-foreground", textClass)}>
+        {average.toFixed(1)}
+      </span>
+      {showCount && (
+        <span className={cn("text-muted-foreground", textClass)}>({count})</span>
+      )}
+    </span>
+  );
+}
+
+/**
+ * Interactive star picker. Submits to the enclosing route's action as soon as
+ * a star is clicked — there is no written review to compose, so there is
+ * nothing to confirm.
+ */
+export function RateCourseForm({
+  currentRating,
+  className,
+}: {
+  currentRating: number | null;
+  className?: string;
+}) {
+  const [hovered, setHovered] = useState<number | null>(null);
+  const navigation = useNavigation();
+  const isSubmitting = navigation.formData?.get("intent") === "rate";
+
+  // Optimistically reflect the star being submitted.
+  const submitted = navigation.formData?.get("rating");
+  const pendingRating = submitted ? Number(submitted) : null;
+  const active = hovered ?? pendingRating ?? currentRating ?? 0;
+
+  return (
+    <Form method="post" className={cn("space-y-2", className)}>
+      <input type="hidden" name="intent" value="rate" />
+      <div
+        className="flex items-center gap-1"
+        onMouseLeave={() => setHovered(null)}
+      >
+        {STARS.map((star) => (
+          <button
+            key={star}
+            type="submit"
+            name="rating"
+            value={star}
+            disabled={isSubmitting}
+            onMouseEnter={() => setHovered(star)}
+            onFocus={() => setHovered(star)}
+            onBlur={() => setHovered(null)}
+            aria-label={`Rate ${star} out of ${MAX_RATING}`}
+            className="rounded p-0.5 transition-transform hover:scale-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed"
+          >
+            <Star
+              className={cn(
+                "size-6",
+                star <= active
+                  ? "fill-amber-400 text-amber-400"
+                  : "text-muted-foreground/40"
+              )}
+            />
+          </button>
+        ))}
+      </div>
+      <p className="text-xs text-muted-foreground">
+        {currentRating
+          ? `You rated this ${currentRating} out of ${MAX_RATING}. Click to change.`
+          : "Tap a star to rate this course."}
+      </p>
+    </Form>
+  );
+}

--- a/app/db/schema.ts
+++ b/app/db/schema.ts
@@ -1,4 +1,10 @@
-import { sqliteTable, text, integer, real } from "drizzle-orm/sqlite-core";
+import {
+  sqliteTable,
+  text,
+  integer,
+  real,
+  uniqueIndex,
+} from "drizzle-orm/sqlite-core";
 
 export enum UserRole {
   Student = "student",
@@ -238,6 +244,36 @@ export const coupons = sqliteTable("coupons", {
     .notNull()
     .$defaultFn(() => new Date().toISOString()),
 });
+
+// Star-only course reviews: one rating per user per course, no written body.
+export const MIN_RATING = 1;
+export const MAX_RATING = 5;
+
+export const courseRatings = sqliteTable(
+  "course_ratings",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    userId: integer("user_id")
+      .notNull()
+      .references(() => users.id),
+    courseId: integer("course_id")
+      .notNull()
+      .references(() => courses.id),
+    rating: integer("rating").notNull(),
+    createdAt: text("created_at")
+      .notNull()
+      .$defaultFn(() => new Date().toISOString()),
+    updatedAt: text("updated_at")
+      .notNull()
+      .$defaultFn(() => new Date().toISOString()),
+  },
+  (table) => [
+    uniqueIndex("course_ratings_user_course_idx").on(
+      table.userId,
+      table.courseId
+    ),
+  ]
+);
 
 export const videoWatchEvents = sqliteTable("video_watch_events", {
   id: integer("id").primaryKey({ autoIncrement: true }),

--- a/app/routes/courses.$slug.tsx
+++ b/app/routes/courses.$slug.tsx
@@ -1,12 +1,19 @@
 import { useEffect } from "react";
 import { Link, useSearchParams } from "react-router";
 import { toast } from "sonner";
+import { z } from "zod";
 import type { Route } from "./+types/courses.$slug";
 import {
   getCourseBySlug,
   getCourseWithDetails,
   getLessonCountForCourse,
 } from "~/services/courseService";
+import {
+  canUserRateCourse,
+  getCourseRatingSummary,
+  getUserRating,
+  rateCourse,
+} from "~/services/ratingService";
 import { isUserEnrolled } from "~/services/enrollmentService";
 import {
   calculateProgress,
@@ -14,7 +21,8 @@ import {
   getNextIncompleteLesson,
 } from "~/services/progressService";
 import { getCurrentUserId } from "~/lib/session";
-import { LessonProgressStatus } from "~/db/schema";
+import { parseFormData } from "~/lib/validation";
+import { LessonProgressStatus, MAX_RATING, MIN_RATING } from "~/db/schema";
 import { Card, CardContent, CardHeader } from "~/components/ui/card";
 import { Button } from "~/components/ui/button";
 import { Skeleton } from "~/components/ui/skeleton";
@@ -37,6 +45,7 @@ import {
 } from "lucide-react";
 import { CourseImage } from "~/components/course-image";
 import { UserAvatar } from "~/components/user-avatar";
+import { RateCourseForm, StarRating } from "~/components/star-rating";
 import { data, isRouteErrorResponse } from "react-router";
 import { formatDuration, formatPrice } from "~/lib/utils";
 import { renderMarkdown } from "~/lib/markdown.server";
@@ -102,6 +111,14 @@ export async function loader({ params, request }: Route.LoaderArgs) {
     : courseWithDetails.price;
   const tierInfo = getCountryTierInfo(country);
 
+  const ratingSummary = getCourseRatingSummary(course.id);
+  const canRate = currentUserId
+    ? canUserRateCourse(currentUserId, course.id)
+    : false;
+  const userRating = currentUserId
+    ? (getUserRating(currentUserId, course.id)?.rating ?? null)
+    : null;
+
   return {
     course: courseWithDetails,
     salesCopyHtml,
@@ -113,10 +130,47 @@ export async function loader({ params, request }: Route.LoaderArgs) {
     currentUserId,
     pppPrice,
     tierInfo,
+    ratingSummary,
+    canRate,
+    userRating,
   };
 }
 
-// No action — enrollment is handled via the purchase confirmation page
+// Enrollment is handled via the purchase confirmation page; the only action
+// here is leaving a star rating.
+const rateSchema = z.object({
+  intent: z.literal("rate"),
+  rating: z.coerce.number().int().min(MIN_RATING).max(MAX_RATING),
+});
+
+export async function action({ params, request }: Route.ActionArgs) {
+  const currentUserId = await getCurrentUserId(request);
+  if (!currentUserId) {
+    throw data("Sign in to rate this course", { status: 401 });
+  }
+
+  const course = getCourseBySlug(params.slug);
+  if (!course) {
+    throw data("Course not found", { status: 404 });
+  }
+
+  const formData = await request.formData();
+  const parsed = parseFormData(formData, rateSchema);
+
+  if (!parsed.success) {
+    return {
+      error: `Please choose a rating between ${MIN_RATING} and ${MAX_RATING} stars.`,
+    };
+  }
+
+  if (!canUserRateCourse(currentUserId, course.id)) {
+    throw data("Only enrolled students can rate this course", { status: 403 });
+  }
+
+  rateCourse(currentUserId, course.id, parsed.data.rating);
+
+  return { error: null };
+}
 
 export function HydrateFallback() {
   return (
@@ -169,7 +223,10 @@ export function HydrateFallback() {
   );
 }
 
-export default function CourseDetail({ loaderData }: Route.ComponentProps) {
+export default function CourseDetail({
+  loaderData,
+  actionData,
+}: Route.ComponentProps) {
   const {
     course,
     salesCopyHtml,
@@ -181,6 +238,9 @@ export default function CourseDetail({ loaderData }: Route.ComponentProps) {
     currentUserId,
     pppPrice,
     tierInfo,
+    ratingSummary,
+    canRate,
+    userRating,
   } = loaderData;
   const isInstructor = currentUserId === course.instructorId;
   const [searchParams, setSearchParams] = useSearchParams();
@@ -320,6 +380,10 @@ export default function CourseDetail({ loaderData }: Route.ComponentProps) {
               {formatDuration(totalDuration, true, false, false)} total
             </span>
           )}
+          <StarRating
+            average={ratingSummary.average}
+            count={ratingSummary.count}
+          />
         </div>
       </div>
 
@@ -442,6 +506,18 @@ export default function CourseDetail({ loaderData }: Route.ComponentProps) {
                   </p>
                 )}
               </div>
+
+              {canRate && (
+                <div className="border-t pt-4">
+                  <h3 className="mb-2 text-sm font-medium">Rate this course</h3>
+                  <RateCourseForm currentRating={userRating} />
+                  {actionData?.error && (
+                    <p className="mt-2 text-xs text-destructive">
+                      {actionData.error}
+                    </p>
+                  )}
+                </div>
+              )}
             </CardContent>
           </Card>
         </div>

--- a/app/routes/courses.tsx
+++ b/app/routes/courses.tsx
@@ -9,6 +9,11 @@ import { Skeleton } from "~/components/ui/skeleton";
 import { AlertTriangle, BookOpen, Search } from "lucide-react";
 import { CourseImage } from "~/components/course-image";
 import { UserAvatar } from "~/components/user-avatar";
+import { StarRating } from "~/components/star-rating";
+import {
+  emptyRatingSummary,
+  getRatingSummariesForCourses,
+} from "~/services/ratingService";
 import { getCurrentUserId } from "~/lib/session";
 import { formatPrice } from "~/lib/utils";
 import { getUserEnrolledCourses } from "~/services/enrollmentService";
@@ -55,6 +60,10 @@ export async function loader({ request }: Route.LoaderArgs) {
     }
   }
 
+  const ratingSummaries = getRatingSummariesForCourses(
+    courses.map((course) => course.id)
+  );
+
   const coursesWithLessonCount = courses.map((course) => {
     const userProgress = progressMap.get(course.id);
     const pppPrice = course.pppEnabled
@@ -66,6 +75,7 @@ export async function loader({ request }: Route.LoaderArgs) {
       progress: userProgress?.progress ?? null,
       completedLessons: userProgress?.completedLessons ?? null,
       pppPrice,
+      rating: ratingSummaries.get(course.id) ?? emptyRatingSummary(),
     };
   });
 
@@ -204,6 +214,13 @@ export default function CourseCatalog({ loaderData }: Route.ComponentProps) {
                   <h3 className="text-lg font-semibold leading-tight group-hover:text-primary">
                     {course.title}
                   </h3>
+                  {course.rating.count > 0 && (
+                    <StarRating
+                      average={course.rating.average}
+                      count={course.rating.count}
+                      className="mt-1"
+                    />
+                  )}
                 </CardHeader>
                 <CardContent>
                   <p className="line-clamp-2 text-sm text-muted-foreground">

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -8,6 +8,11 @@ import { getAllCategories } from "~/services/categoryService";
 import { CourseStatus } from "~/db/schema";
 import { BookOpen, GraduationCap, Users, ArrowRight, User, Moon, Sun } from "lucide-react";
 import { CourseImage } from "~/components/course-image";
+import { StarRating } from "~/components/star-rating";
+import {
+  emptyRatingSummary,
+  getRatingSummariesForCourses,
+} from "~/services/ratingService";
 import { DevUI } from "~/components/dev-ui";
 import { getAllUsers, getUserById } from "~/services/userService";
 import { getCurrentUserId, getDevCountry } from "~/lib/session";
@@ -22,9 +27,14 @@ export function meta({}: Route.MetaArgs) {
 
 export async function loader({ request }: Route.LoaderArgs) {
   const courses = buildCourseQuery(null, null, CourseStatus.Published, "newest", 50, 0);
-  const featured = courses.slice(0, 3).map((course) => ({
+  const featuredCourses = courses.slice(0, 3);
+  const ratingSummaries = getRatingSummariesForCourses(
+    featuredCourses.map((course) => course.id)
+  );
+  const featured = featuredCourses.map((course) => ({
     ...course,
     lessonCount: getLessonCountForCourse(course.id),
+    rating: ratingSummaries.get(course.id) ?? emptyRatingSummary(),
   }));
   const categories = getAllCategories();
   const users = getAllUsers();
@@ -181,6 +191,13 @@ export default function Home({ loaderData }: Route.ComponentProps) {
                     <h3 className="font-semibold leading-snug group-hover:text-primary">
                       {course.title}
                     </h3>
+                    {course.rating.count > 0 && (
+                      <StarRating
+                        average={course.rating.average}
+                        count={course.rating.count}
+                        className="mt-1"
+                      />
+                    )}
                   </CardHeader>
                   <CardContent>
                     <p className="line-clamp-2 text-sm text-muted-foreground">

--- a/app/services/ratingService.test.ts
+++ b/app/services/ratingService.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { createTestDb, seedBaseData } from "~/test/setup";
+import * as schema from "~/db/schema";
+
+let testDb: ReturnType<typeof createTestDb>;
+let base: ReturnType<typeof seedBaseData>;
+
+vi.mock("~/db", () => ({
+  get db() {
+    return testDb;
+  },
+}));
+
+// Import after mock so the module picks up our test db
+import {
+  canUserRateCourse,
+  getCourseRatingSummary,
+  getRatingSummariesForCourses,
+  getRatingsByCourse,
+  getUserRating,
+  rateCourse,
+  removeRating,
+} from "./ratingService";
+
+/** Creates an extra student and enrolls them, so we can average across users. */
+function enrolledStudent(email: string) {
+  const user = testDb
+    .insert(schema.users)
+    .values({ name: email, email, role: schema.UserRole.Student })
+    .returning()
+    .get();
+
+  testDb
+    .insert(schema.enrollments)
+    .values({ userId: user.id, courseId: base.course.id })
+    .run();
+
+  return user;
+}
+
+describe("ratingService", () => {
+  beforeEach(() => {
+    testDb = createTestDb();
+    base = seedBaseData(testDb);
+
+    // The base student is enrolled in the base course for most tests.
+    testDb
+      .insert(schema.enrollments)
+      .values({ userId: base.user.id, courseId: base.course.id })
+      .run();
+  });
+
+  describe("rateCourse", () => {
+    it("records a rating for an enrolled student", () => {
+      const rating = rateCourse(base.user.id, base.course.id, 4);
+
+      expect(rating.userId).toBe(base.user.id);
+      expect(rating.courseId).toBe(base.course.id);
+      expect(rating.rating).toBe(4);
+    });
+
+    it("overwrites the previous rating instead of adding a second one", () => {
+      rateCourse(base.user.id, base.course.id, 2);
+      const updated = rateCourse(base.user.id, base.course.id, 5);
+
+      expect(updated.rating).toBe(5);
+      expect(getRatingsByCourse(base.course.id)).toHaveLength(1);
+    });
+
+    it("rejects ratings outside 1–5", () => {
+      expect(() => rateCourse(base.user.id, base.course.id, 0)).toThrowError(
+        /between 1 and 5/
+      );
+      expect(() => rateCourse(base.user.id, base.course.id, 6)).toThrowError(
+        /between 1 and 5/
+      );
+    });
+
+    it("rejects fractional ratings", () => {
+      expect(() => rateCourse(base.user.id, base.course.id, 3.5)).toThrowError(
+        /between 1 and 5/
+      );
+    });
+
+    it("rejects a student who is not enrolled", () => {
+      const outsider = testDb
+        .insert(schema.users)
+        .values({
+          name: "Outsider",
+          email: "outsider@example.com",
+          role: schema.UserRole.Student,
+        })
+        .returning()
+        .get();
+
+      expect(() => rateCourse(outsider.id, base.course.id, 5)).toThrowError(
+        "Only enrolled students can rate this course"
+      );
+    });
+
+    it("rejects the instructor rating their own course", () => {
+      // Enrolled or not, the course owner must not rate their own course.
+      testDb
+        .insert(schema.enrollments)
+        .values({ userId: base.instructor.id, courseId: base.course.id })
+        .run();
+
+      expect(() =>
+        rateCourse(base.instructor.id, base.course.id, 5)
+      ).toThrowError("Only enrolled students can rate this course");
+    });
+
+    it("rejects a rating for a non-existent course", () => {
+      expect(() => rateCourse(base.user.id, 9999, 5)).toThrowError(
+        "Only enrolled students can rate this course"
+      );
+    });
+  });
+
+  describe("getUserRating", () => {
+    it("returns the rating the user left", () => {
+      rateCourse(base.user.id, base.course.id, 3);
+
+      expect(getUserRating(base.user.id, base.course.id)?.rating).toBe(3);
+    });
+
+    it("returns undefined when the user has not rated", () => {
+      expect(getUserRating(base.user.id, base.course.id)).toBeUndefined();
+    });
+  });
+
+  describe("getCourseRatingSummary", () => {
+    it("returns an empty summary when there are no ratings", () => {
+      expect(getCourseRatingSummary(base.course.id)).toEqual({
+        average: null,
+        count: 0,
+      });
+    });
+
+    it("averages ratings across users", () => {
+      rateCourse(base.user.id, base.course.id, 5);
+      rateCourse(enrolledStudent("b@example.com").id, base.course.id, 4);
+
+      expect(getCourseRatingSummary(base.course.id)).toEqual({
+        average: 4.5,
+        count: 2,
+      });
+    });
+
+    it("rounds the average to one decimal", () => {
+      rateCourse(base.user.id, base.course.id, 5);
+      rateCourse(enrolledStudent("b@example.com").id, base.course.id, 4);
+      rateCourse(enrolledStudent("c@example.com").id, base.course.id, 4);
+
+      // 13 / 3 = 4.333…
+      expect(getCourseRatingSummary(base.course.id).average).toBe(4.3);
+    });
+
+    it("reflects an overwritten rating rather than counting it twice", () => {
+      rateCourse(base.user.id, base.course.id, 1);
+      rateCourse(base.user.id, base.course.id, 5);
+
+      expect(getCourseRatingSummary(base.course.id)).toEqual({
+        average: 5,
+        count: 1,
+      });
+    });
+  });
+
+  describe("getRatingSummariesForCourses", () => {
+    it("returns a summary per course id", () => {
+      const otherCourse = testDb
+        .insert(schema.courses)
+        .values({
+          title: "Other Course",
+          slug: "other-course",
+          description: "Another test course",
+          instructorId: base.instructor.id,
+          categoryId: base.category.id,
+          status: schema.CourseStatus.Published,
+        })
+        .returning()
+        .get();
+
+      testDb
+        .insert(schema.enrollments)
+        .values({ userId: base.user.id, courseId: otherCourse.id })
+        .run();
+
+      rateCourse(base.user.id, base.course.id, 2);
+      rateCourse(base.user.id, otherCourse.id, 4);
+
+      const summaries = getRatingSummariesForCourses([
+        base.course.id,
+        otherCourse.id,
+      ]);
+
+      expect(summaries.get(base.course.id)).toEqual({ average: 2, count: 1 });
+      expect(summaries.get(otherCourse.id)).toEqual({ average: 4, count: 1 });
+    });
+
+    it("omits courses that have no ratings", () => {
+      const summaries = getRatingSummariesForCourses([base.course.id]);
+
+      expect(summaries.has(base.course.id)).toBe(false);
+    });
+
+    it("returns an empty map for an empty id list", () => {
+      expect(getRatingSummariesForCourses([]).size).toBe(0);
+    });
+  });
+
+  describe("canUserRateCourse", () => {
+    it("allows an enrolled student", () => {
+      expect(canUserRateCourse(base.user.id, base.course.id)).toBe(true);
+    });
+
+    it("denies a student who is not enrolled", () => {
+      const outsider = testDb
+        .insert(schema.users)
+        .values({
+          name: "Outsider",
+          email: "outsider@example.com",
+          role: schema.UserRole.Student,
+        })
+        .returning()
+        .get();
+
+      expect(canUserRateCourse(outsider.id, base.course.id)).toBe(false);
+    });
+
+    it("denies the course instructor", () => {
+      expect(canUserRateCourse(base.instructor.id, base.course.id)).toBe(false);
+    });
+
+    it("denies a non-existent course", () => {
+      expect(canUserRateCourse(base.user.id, 9999)).toBe(false);
+    });
+  });
+
+  describe("removeRating", () => {
+    it("deletes the user's rating", () => {
+      rateCourse(base.user.id, base.course.id, 3);
+      removeRating(base.user.id, base.course.id);
+
+      expect(getUserRating(base.user.id, base.course.id)).toBeUndefined();
+      expect(getCourseRatingSummary(base.course.id).count).toBe(0);
+    });
+
+    it("throws when there is nothing to remove", () => {
+      expect(() => removeRating(base.user.id, base.course.id)).toThrowError(
+        "User has not rated this course"
+      );
+    });
+  });
+});

--- a/app/services/ratingService.ts
+++ b/app/services/ratingService.ts
@@ -1,0 +1,168 @@
+import { eq, and, inArray, sql } from "drizzle-orm";
+import { db } from "~/db";
+import {
+  courseRatings,
+  courses,
+  enrollments,
+  MAX_RATING,
+  MIN_RATING,
+} from "~/db/schema";
+
+// ─── Rating Service ───
+// Handles star-only course ratings (no written reviews). One rating per user
+// per course; re-rating overwrites the previous value.
+// Uses positional parameters (project convention).
+
+export type RatingSummary = {
+  /** Mean rating rounded to one decimal, or null when nothing has been rated. */
+  average: number | null;
+  count: number;
+};
+
+const EMPTY_SUMMARY: RatingSummary = { average: null, count: 0 };
+
+export function getRatingById(id: number) {
+  return db.select().from(courseRatings).where(eq(courseRatings.id, id)).get();
+}
+
+export function getUserRating(userId: number, courseId: number) {
+  return db
+    .select()
+    .from(courseRatings)
+    .where(
+      and(
+        eq(courseRatings.userId, userId),
+        eq(courseRatings.courseId, courseId)
+      )
+    )
+    .get();
+}
+
+export function getRatingsByCourse(courseId: number) {
+  return db
+    .select()
+    .from(courseRatings)
+    .where(eq(courseRatings.courseId, courseId))
+    .all();
+}
+
+export function getCourseRatingSummary(courseId: number): RatingSummary {
+  const result = db
+    .select({
+      average: sql<number | null>`avg(${courseRatings.rating})`,
+      count: sql<number>`count(*)`,
+    })
+    .from(courseRatings)
+    .where(eq(courseRatings.courseId, courseId))
+    .get();
+
+  if (!result || result.count === 0) return EMPTY_SUMMARY;
+
+  return {
+    average: roundToOneDecimal(result.average),
+    count: result.count,
+  };
+}
+
+/**
+ * Batched version of getCourseRatingSummary for list views, so rendering a
+ * grid of courses stays a single query. Course ids with no ratings are absent
+ * from the map — callers should fall back to an empty summary.
+ */
+export function getRatingSummariesForCourses(courseIds: number[]) {
+  const summaries = new Map<number, RatingSummary>();
+
+  if (courseIds.length === 0) return summaries;
+
+  const rows = db
+    .select({
+      courseId: courseRatings.courseId,
+      average: sql<number | null>`avg(${courseRatings.rating})`,
+      count: sql<number>`count(*)`,
+    })
+    .from(courseRatings)
+    .where(inArray(courseRatings.courseId, courseIds))
+    .groupBy(courseRatings.courseId)
+    .all();
+
+  for (const row of rows) {
+    summaries.set(row.courseId, {
+      average: roundToOneDecimal(row.average),
+      count: row.count,
+    });
+  }
+
+  return summaries;
+}
+
+export function emptyRatingSummary(): RatingSummary {
+  return EMPTY_SUMMARY;
+}
+
+/**
+ * Only enrolled students may rate, and instructors may not rate their own
+ * course. Mirrors the check enforced in rateCourse.
+ */
+export function canUserRateCourse(userId: number, courseId: number) {
+  const course = db
+    .select({ instructorId: courses.instructorId })
+    .from(courses)
+    .where(eq(courses.id, courseId))
+    .get();
+
+  if (!course) return false;
+  if (course.instructorId === userId) return false;
+
+  return !!db
+    .select({ id: enrollments.id })
+    .from(enrollments)
+    .where(
+      and(eq(enrollments.userId, userId), eq(enrollments.courseId, courseId))
+    )
+    .get();
+}
+
+export function rateCourse(userId: number, courseId: number, rating: number) {
+  if (!Number.isInteger(rating) || rating < MIN_RATING || rating > MAX_RATING) {
+    throw new Error(`Rating must be a whole number between ${MIN_RATING} and ${MAX_RATING}`);
+  }
+
+  if (!canUserRateCourse(userId, courseId)) {
+    throw new Error("Only enrolled students can rate this course");
+  }
+
+  const existing = getUserRating(userId, courseId);
+
+  if (existing) {
+    return db
+      .update(courseRatings)
+      .set({ rating, updatedAt: new Date().toISOString() })
+      .where(eq(courseRatings.id, existing.id))
+      .returning()
+      .get();
+  }
+
+  return db
+    .insert(courseRatings)
+    .values({ userId, courseId, rating })
+    .returning()
+    .get();
+}
+
+export function removeRating(userId: number, courseId: number) {
+  const existing = getUserRating(userId, courseId);
+  if (!existing) {
+    throw new Error("User has not rated this course");
+  }
+
+  return db
+    .delete(courseRatings)
+    .where(eq(courseRatings.id, existing.id))
+    .returning()
+    .get();
+}
+
+function roundToOneDecimal(value: number | null) {
+  if (value === null) return null;
+  return Math.round(value * 10) / 10;
+}

--- a/drizzle/0003_salty_slipstream.sql
+++ b/drizzle/0003_salty_slipstream.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `course_ratings` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`user_id` integer NOT NULL,
+	`course_id` integer NOT NULL,
+	`rating` integer NOT NULL,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`course_id`) REFERENCES `courses`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `course_ratings_user_course_idx` ON `course_ratings` (`user_id`,`course_id`);

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,1341 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "5344dff6-de6b-4503-bcab-fc3347add34b",
+  "prevId": "4df4a2bc-2402-47ab-a1fa-61e39d1627c7",
+  "tables": {
+    "categories": {
+      "name": "categories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "categories_slug_unique": {
+          "name": "categories_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "coupons": {
+      "name": "coupons",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "purchase_id": {
+          "name": "purchase_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "redeemed_by_user_id": {
+          "name": "redeemed_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "redeemed_at": {
+          "name": "redeemed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "coupons_code_unique": {
+          "name": "coupons_code_unique",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "coupons_team_id_teams_id_fk": {
+          "name": "coupons_team_id_teams_id_fk",
+          "tableFrom": "coupons",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "coupons_course_id_courses_id_fk": {
+          "name": "coupons_course_id_courses_id_fk",
+          "tableFrom": "coupons",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "coupons_purchase_id_purchases_id_fk": {
+          "name": "coupons_purchase_id_purchases_id_fk",
+          "tableFrom": "coupons",
+          "tableTo": "purchases",
+          "columnsFrom": [
+            "purchase_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "coupons_redeemed_by_user_id_users_id_fk": {
+          "name": "coupons_redeemed_by_user_id_users_id_fk",
+          "tableFrom": "coupons",
+          "tableTo": "users",
+          "columnsFrom": [
+            "redeemed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "course_ratings": {
+      "name": "course_ratings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "course_ratings_user_course_idx": {
+          "name": "course_ratings_user_course_idx",
+          "columns": [
+            "user_id",
+            "course_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "course_ratings_user_id_users_id_fk": {
+          "name": "course_ratings_user_id_users_id_fk",
+          "tableFrom": "course_ratings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "course_ratings_course_id_courses_id_fk": {
+          "name": "course_ratings_course_id_courses_id_fk",
+          "tableFrom": "course_ratings",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "courses": {
+      "name": "courses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sales_copy": {
+          "name": "sales_copy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "instructor_id": {
+          "name": "instructor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cover_image_url": {
+          "name": "cover_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "ppp_enabled": {
+          "name": "ppp_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "courses_slug_unique": {
+          "name": "courses_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "courses_instructor_id_users_id_fk": {
+          "name": "courses_instructor_id_users_id_fk",
+          "tableFrom": "courses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "instructor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "courses_category_id_categories_id_fk": {
+          "name": "courses_category_id_categories_id_fk",
+          "tableFrom": "courses",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "enrollments": {
+      "name": "enrollments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enrolled_at": {
+          "name": "enrolled_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "enrollments_user_id_users_id_fk": {
+          "name": "enrollments_user_id_users_id_fk",
+          "tableFrom": "enrollments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "enrollments_course_id_courses_id_fk": {
+          "name": "enrollments_course_id_courses_id_fk",
+          "tableFrom": "enrollments",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "lesson_progress": {
+      "name": "lesson_progress",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lesson_progress_user_id_users_id_fk": {
+          "name": "lesson_progress_user_id_users_id_fk",
+          "tableFrom": "lesson_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lesson_progress_lesson_id_lessons_id_fk": {
+          "name": "lesson_progress_lesson_id_lessons_id_fk",
+          "tableFrom": "lesson_progress",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "lessons": {
+      "name": "lessons",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "module_id": {
+          "name": "module_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "video_url": {
+          "name": "video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_repo_url": {
+          "name": "github_repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lessons_module_id_modules_id_fk": {
+          "name": "lessons_module_id_modules_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "modules",
+          "columnsFrom": [
+            "module_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "modules": {
+      "name": "modules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "modules_course_id_courses_id_fk": {
+          "name": "modules_course_id_courses_id_fk",
+          "tableFrom": "modules",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "purchases": {
+      "name": "purchases",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "price_paid": {
+          "name": "price_paid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "purchases_user_id_users_id_fk": {
+          "name": "purchases_user_id_users_id_fk",
+          "tableFrom": "purchases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "purchases_course_id_courses_id_fk": {
+          "name": "purchases_course_id_courses_id_fk",
+          "tableFrom": "purchases",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quiz_answers": {
+      "name": "quiz_answers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "selected_option_id": {
+          "name": "selected_option_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quiz_answers_attempt_id_quiz_attempts_id_fk": {
+          "name": "quiz_answers_attempt_id_quiz_attempts_id_fk",
+          "tableFrom": "quiz_answers",
+          "tableTo": "quiz_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "quiz_answers_question_id_quiz_questions_id_fk": {
+          "name": "quiz_answers_question_id_quiz_questions_id_fk",
+          "tableFrom": "quiz_answers",
+          "tableTo": "quiz_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "quiz_answers_selected_option_id_quiz_options_id_fk": {
+          "name": "quiz_answers_selected_option_id_quiz_options_id_fk",
+          "tableFrom": "quiz_answers",
+          "tableTo": "quiz_options",
+          "columnsFrom": [
+            "selected_option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quiz_attempts": {
+      "name": "quiz_attempts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quiz_id": {
+          "name": "quiz_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "passed": {
+          "name": "passed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quiz_attempts_user_id_users_id_fk": {
+          "name": "quiz_attempts_user_id_users_id_fk",
+          "tableFrom": "quiz_attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "quiz_attempts_quiz_id_quizzes_id_fk": {
+          "name": "quiz_attempts_quiz_id_quizzes_id_fk",
+          "tableFrom": "quiz_attempts",
+          "tableTo": "quizzes",
+          "columnsFrom": [
+            "quiz_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quiz_options": {
+      "name": "quiz_options",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "option_text": {
+          "name": "option_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quiz_options_question_id_quiz_questions_id_fk": {
+          "name": "quiz_options_question_id_quiz_questions_id_fk",
+          "tableFrom": "quiz_options",
+          "tableTo": "quiz_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quiz_questions": {
+      "name": "quiz_questions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "quiz_id": {
+          "name": "quiz_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "question_text": {
+          "name": "question_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "question_type": {
+          "name": "question_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quiz_questions_quiz_id_quizzes_id_fk": {
+          "name": "quiz_questions_quiz_id_quizzes_id_fk",
+          "tableFrom": "quiz_questions",
+          "tableTo": "quizzes",
+          "columnsFrom": [
+            "quiz_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quizzes": {
+      "name": "quizzes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "passing_score": {
+          "name": "passing_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quizzes_lesson_id_lessons_id_fk": {
+          "name": "quizzes_lesson_id_lessons_id_fk",
+          "tableFrom": "quizzes",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team_members": {
+      "name": "team_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_members_team_id_teams_id_fk": {
+          "name": "team_members_team_id_teams_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_members_user_id_users_id_fk": {
+          "name": "team_members_user_id_users_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "teams": {
+      "name": "teams",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "video_watch_events": {
+      "name": "video_watch_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position_seconds": {
+          "name": "position_seconds",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "video_watch_events_user_id_users_id_fk": {
+          "name": "video_watch_events_user_id_users_id_fk",
+          "tableFrom": "video_watch_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "video_watch_events_lesson_id_lessons_id_fk": {
+          "name": "video_watch_events_lesson_id_lessons_id_fk",
+          "tableFrom": "video_watch_events",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1770650640202,
       "tag": "0002_lying_shriek",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1785371590993,
+      "tag": "0003_salty_slipstream",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -45,6 +45,7 @@ async function seed() {
 
   // Drop and recreate tables for a clean seed
   sqlite.exec(`
+    DROP TABLE IF EXISTS course_ratings;
     DROP TABLE IF EXISTS video_watch_events;
     DROP TABLE IF EXISTS quiz_answers;
     DROP TABLE IF EXISTS quiz_attempts;
@@ -1727,6 +1728,25 @@ You've completed the Building REST APIs course. You now have the skills to build
     `Created 1 team with Bossy McBossface as admin, 1 team purchase, and ${seededCoupons.length} coupons (2 redeemed, 3 available).`
   );
 
+  // ─── Course Ratings ───
+  // Star-only ratings from enrolled students. Course 1 averages 4.5 across
+  // 4 raters; course 2 averages 4.0 across 3, so the two courses render
+  // differently in the catalog.
+
+  db.insert(schema.courseRatings)
+    .values([
+      { userId: students[0].id, courseId: course1.id, rating: 5, createdAt: daysAgo(20), updatedAt: daysAgo(20) },
+      { userId: students[1].id, courseId: course1.id, rating: 5, createdAt: daysAgo(9), updatedAt: daysAgo(9) },
+      { userId: students[2].id, courseId: course1.id, rating: 4, createdAt: daysAgo(18), updatedAt: daysAgo(18) },
+      { userId: students[4].id, courseId: course1.id, rating: 4, createdAt: daysAgo(5), updatedAt: daysAgo(5) },
+      { userId: students[0].id, courseId: course2.id, rating: 4, createdAt: daysAgo(15), updatedAt: daysAgo(15) },
+      { userId: students[2].id, courseId: course2.id, rating: 5, createdAt: daysAgo(12), updatedAt: daysAgo(12) },
+      { userId: students[3].id, courseId: course2.id, rating: 3, createdAt: daysAgo(8), updatedAt: daysAgo(8) },
+    ])
+    .run();
+
+  console.log("Created 7 course ratings.");
+
   console.log("\n✓ Seed complete!");
   console.log("  Users: 9 (1 admin, 2 instructors, 6 students)");
   console.log("  Categories: 5");
@@ -1735,6 +1755,7 @@ You've completed the Building REST APIs course. You now have the skills to build
   );
   console.log("  Quizzes: 3");
   console.log("  Enrollments: 7");
+  console.log("  Course ratings: 7");
   console.log("  Purchases: 6 (5 individual + 1 team)");
   console.log("  Teams: 1 (with 5 coupons)");
 }


### PR DESCRIPTION
Enrolled students can leave a 1-5 star rating on a course detail page, with no written review body. A unique index on (user_id, course_id) keeps it to one rating per user per course; re-submitting updates the existing row rather than inserting a second one.

Average and count render on the course detail page, the catalog, and the featured cards on the home page. The catalog and home loaders batch their lookups through getRatingSummariesForCourses so listing N courses stays a single query.

The rate action re-checks enrollment server-side via canUserRateCourse, so hiding the form is presentation only, not the access control.